### PR TITLE
Ensure backend DB path is clearly defined

### DIFF
--- a/backend/database.js
+++ b/backend/database.js
@@ -1,5 +1,7 @@
 const sqlite3 = require('sqlite3').verbose();
-const DBSOURCE = "securewalkways.db";
+const path = require('path');
+// Resolve the database path relative to this file so it lives in the backend folder
+const DBSOURCE = path.join(__dirname, 'securewalkways.db');
 
 let db = new sqlite3.Database(DBSOURCE, (err) => {
     if (err) {


### PR DESCRIPTION
## Summary
- make `backend/database.js` resolve the SQLite path relative to the backend folder
- run backend test suite

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68458c091ac88329a895ae9d4054c819